### PR TITLE
rename extension to smbclient, fix #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,54 @@
+# Local config
 phpunit.xml
+
+# Object files
+*.o
+*.lo
+
+# Libraries
+*.lib
+*.a
+*.la
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# autotools
+.deps
+.libs
+config.cache
+config.guess
+config.h
+config.h.in
+config.log
+config.nice
+config.status
+config.sub
+configure
+configure.in
+conftest
+conftest.c
+Makefile
+Makefile.fragments
+Makefile.global
+Makefile.objects
+acinclude.m4
+aclocal.m4
+autom4te.cache
+build
+install-sh
+libtool
+ltmain.sh
+ltmain.sh.backup
+missing
+mkinstalldirs
+modules
+run-tests.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ script:
   - ./configure
   - make
   - sudo make install
-  - echo 'extension="libsmbclient.so"' | sudo tee -a /etc/php5/cli/php.ini
+  - echo 'extension="smbclient.so"' | sudo tee -a /etc/php5/cli/php.ini
   - /usr/bin/php phpunit.phar --verbose

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,9 +1,0 @@
-LTLIBRARY_NAME    = libsmbclient.la
-LTLIBRARY_SOURCES = libsmbclient.c
-LTLIBRARY_LIBADD  = $(LIBSMBCLIENT_LIBADD)
-LTLIBRARY_SHARED_NAME    = libsmbclient.la
-LTLIBRARY_SHARED_LIBADD  = $(LIBSMBCLIENT_SHARED_LIBADD)
-
-SUBDIRS = $(LIBSMBCLIENT_SUBDIRS)
-
-include $(top_srcdir)/build/dynlib.mk

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ make install INSTALL_ROOT=/tmp/smbc
 - Activate libsmbclient-php in php.ini:
 
 ```sh
-extension="libsmbclient.so"
+extension="smbclient.so"
 ```
 
 Contributions and bug reports

--- a/config.m4
+++ b/config.m4
@@ -1,16 +1,12 @@
 dnl If your extension references something external, use with:
 
+PHP_ARG_ENABLE(libsmbclient, whether to enable smbclient support,
+[  --enable-smbclient      Enable libsmbclient support])
+
 PHP_ARG_WITH(libsmbclient, for libsmbclient support,
-[  --with-libsmbclient=DIR Include libsmbclient support.
+[  --with-libsmbclient=DIR Installation prefix of libsmbclient.
                           If DIR is not specified, use the system library.])
-
-dnl Otherwise use enable:
-
-dnl PHP_ARG_ENABLE(libsmbclient, whether to enable libsmbclient support,
-dnl Make sure that the comment is aligned:
-dnl [  --enable-libsmbclient           Enable libsmbclient support])
-
-if test "$PHP_LIBSMBCLIENT" != "no"; then
+if test "$PHP_SMBCLIENT" != "no"; then
 
   dnl If a path was given, expect to find the library in $PHP_LIBDIR
   dnl and the include file in include/
@@ -21,7 +17,7 @@ if test "$PHP_LIBSMBCLIENT" != "no"; then
 
     AC_DEFINE(HAVE_LIBSMBCLIENT, 1, [ ])
     PHP_ADD_INCLUDE($LIBSMBCLIENT_INCDIR)
-    PHP_ADD_LIBRARY_WITH_PATH(smbclient, $LIBSMBCLIENT_DIR, LIBSMBCLIENT_SHARED_LIBADD)
+    PHP_ADD_LIBRARY_WITH_PATH(smbclient, $LIBSMBCLIENT_DIR, SMBCLIENT_SHARED_LIBADD)
 
   dnl Otherwise find the header and shared library by the normal means:
   else
@@ -41,13 +37,13 @@ if test "$PHP_LIBSMBCLIENT" != "no"; then
     fi
 
     dnl Find the shared library:
-    PHP_CHECK_LIBRARY(smbclient, smbc_open,
+    PHP_CHECK_LIBRARY(smbclient, smbc_getOptionUserData,
     [
       AC_DEFINE(HAVE_LIBSMBCLIENT, 1, [ ])
       PHP_ADD_INCLUDE($LIBSMBCLIENT_INCDIR)
-      PHP_ADD_LIBRARY(smbclient, 1, LIBSMBCLIENT_SHARED_LIBADD)
+      PHP_ADD_LIBRARY(smbclient, 1, SMBCLIENT_SHARED_LIBADD)
     ],[
-      AC_MSG_ERROR([Could not find libsmbclient.so or symbol smbc_open. Check config.log for more information.])
+      AC_MSG_ERROR([Could not find libsmbclient.so or symbol smbc_getOptionUserData. Check version and config.log for more information.])
     ],[
       -lsmbclient
     ])
@@ -74,7 +70,7 @@ if test "$PHP_LIBSMBCLIENT" != "no"; then
     -lsmbclient
   ])
 
-  PHP_SUBST(LIBSMBCLIENT_SHARED_LIBADD)
-  PHP_NEW_EXTENSION(libsmbclient, libsmbclient.c smb_streams.c, $ext_shared)
+  PHP_SUBST(SMBCLIENT_SHARED_LIBADD)
+  PHP_NEW_EXTENSION(smbclient, smbclient.c smb_streams.c, $ext_shared)
 
 fi

--- a/php_smbclient.h
+++ b/php_smbclient.h
@@ -46,12 +46,12 @@
 #define PHP_SMBCLIENT_VERSION "0.8.0-dev"
 
 extern zend_module_entry smbclient_module_entry;
-#define phpext_libsmbclient_ptr &libsmbclient_module_entry
+#define phpext_smbclient_ptr &smbclient_module_entry
 
 typedef struct {
 } php_smbclient_globals;
 
-typedef struct _php_libsmbclient_state
+typedef struct _php_smbclient_state
 {
 	SMBCCTX *ctx;
 	char *wrkg;
@@ -62,7 +62,7 @@ typedef struct _php_libsmbclient_state
 	int passlen;
 	int err;
 }
-php_libsmbclient_state;
+php_smbclient_state;
 
 PHP_MINIT_FUNCTION(smbclient);
 PHP_MSHUTDOWN_FUNCTION(smbclient);
@@ -102,19 +102,19 @@ PHP_FUNCTION(smbclient_statvfs);
 PHP_FUNCTION(smbclient_fstatvfs);
 
 /* If Zend Thread Safety (ZTS) is defined, each thread gets its own private
- * php_libsmbclient_globals structure, the elements of which it can access
- * through the LIBSMBCLIENT() macro. Without ZTS, there is just one master
+ * php_smbclient_globals structure, the elements of which it can access
+ * through the SMBCLIENT() macro. Without ZTS, there is just one master
  * structure in which we access the members directly: */
 #ifdef ZTS
-#define LIBSMBCLIENT(v) TSRMG(libsmbclient_globals_id, php_libsmbclient_globals *, v)
+#define SMBCLIENT_G(v) TSRMG(smbclient_globals_id, php_smbclient_globals *, v)
 #else
-#define LIBSMBCLIENT(v) (libsmbclient_globals.v)
+#define SMBCLIENT_G(v) (smbclient_globals.v)
 #endif
 
 php_stream_wrapper php_stream_smb_wrapper;
-php_libsmbclient_state * php_libsmbclient_state_new  (php_stream_context *context, int init TSRMLS_DC);
-void                     php_libsmbclient_state_free (php_libsmbclient_state *state TSRMLS_DC);
-int                      php_libsmbclient_state_init (php_libsmbclient_state *state TSRMLS_DC);
-int                      flagstring_to_smbflags (const char *flags, int flags_len, int *retval TSRMLS_DC);
+php_smbclient_state * php_smbclient_state_new  (php_stream_context *context, int init TSRMLS_DC);
+void                  php_smbclient_state_free (php_smbclient_state *state TSRMLS_DC);
+int                   php_smbclient_state_init (php_smbclient_state *state TSRMLS_DC);
+int                   flagstring_to_smbflags (const char *flags, int flags_len, int *retval TSRMLS_DC);
 
 #endif /* PHP_SMBCLIENT_H */

--- a/php_smbclient.h
+++ b/php_smbclient.h
@@ -38,18 +38,18 @@
  * ------------------------------------------------------------------
  */
 
-#ifndef PHP_LIBSMBCLIENT_H
-#define PHP_LIBSMBCLIENT_H
+#ifndef PHP_SMBCLIENT_H
+#define PHP_SMBCLIENT_H
 
 #include <libsmbclient.h>
 
-#define LIBSMBCLIENT_VERSION "0.8.0-dev"
+#define PHP_SMBCLIENT_VERSION "0.8.0-dev"
 
-extern zend_module_entry libsmbclient_module_entry;
+extern zend_module_entry smbclient_module_entry;
 #define phpext_libsmbclient_ptr &libsmbclient_module_entry
 
 typedef struct {
-} php_libsmbclient_globals;
+} php_smbclient_globals;
 
 typedef struct _php_libsmbclient_state
 {
@@ -117,4 +117,4 @@ void                     php_libsmbclient_state_free (php_libsmbclient_state *st
 int                      php_libsmbclient_state_init (php_libsmbclient_state *state TSRMLS_DC);
 int                      flagstring_to_smbflags (const char *flags, int flags_len, int *retval TSRMLS_DC);
 
-#endif /* PHP_LIBSMBCLIENT_H */
+#endif /* PHP_SMBCLIENT_H */

--- a/smb_streams.c
+++ b/smb_streams.c
@@ -46,7 +46,7 @@
 #include "ext/standard/url.h"
 #include "ext/standard/info.h"
 #include "ext/standard/php_filestat.h"
-#include "php_libsmbclient.h"
+#include "php_smbclient.h"
 
 #include <libsmbclient.h>
 

--- a/smb_streams.c
+++ b/smb_streams.c
@@ -54,7 +54,7 @@
 	php_smb_stream_data *self = (php_smb_stream_data *) stream->abstract;
 
 typedef struct _php_smb_stream_data {
-	php_libsmbclient_state *state;
+	php_smbclient_state    *state;
 	SMBCFILE               *handle;
 	/* pointers cache for multiple call */
 	smbc_read_fn            smbc_read;
@@ -81,7 +81,7 @@ static int php_smb_ops_close(php_stream *stream, int close_handle TSRMLS_DC)
 		}
 	}
 
-	php_libsmbclient_state_free(self->state TSRMLS_CC);
+	php_smbclient_state_free(self->state TSRMLS_CC);
 	efree(self);
 	stream->abstract = NULL;
 	return EOF;
@@ -195,7 +195,7 @@ php_stream_smb_opener(
 	php_stream_context *context
 	STREAMS_DC TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state    *state;
 	int                     smbflags;
 	long                    smbmode = 0666;
 	smbc_open_fn            smbc_open;
@@ -203,7 +203,7 @@ php_stream_smb_opener(
 	php_smb_stream_data    *self;
 
 	/* Context */
-	state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 	if (!state) {
 		return NULL;
 	}
@@ -214,15 +214,15 @@ php_stream_smb_opener(
 		mode = "r";
 	}
 	if (flagstring_to_smbflags(mode, strlen(mode), &smbflags TSRMLS_CC) == 0) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return NULL;
 	}
 	if ((smbc_open = smbc_getFunctionOpen(state->ctx)) == NULL) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return NULL;
 	}
 	if ((handle = smbc_open(state->ctx, path, smbflags, smbmode)) == NULL) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return NULL;
 	}
 	self = ecalloc(sizeof(*self), 1);
@@ -244,11 +244,11 @@ php_stream_smb_unlink(
 	php_stream_context *context
 	TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state *state;
 	smbc_unlink_fn smbc_unlink;
 
 	/* Context */
-	state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
@@ -257,17 +257,17 @@ php_stream_smb_unlink(
 		if (options & REPORT_ERRORS) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unlink not supported");
 		}
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_unlink(state->ctx, url) == 0) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 1;
 	}
 	if (options & REPORT_ERRORS) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unlink fails: %s", strerror(errno));
 	}
-	php_libsmbclient_state_free(state TSRMLS_CC);
+	php_smbclient_state_free(state TSRMLS_CC);
 	return 0;
 }
 
@@ -284,7 +284,7 @@ php_stream_smb_mkdir(
 	php_stream_context *context
 	TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state *state;
 	smbc_mkdir_fn smbc_mkdir;
 
 	if (options & PHP_STREAM_MKDIR_RECURSIVE) {
@@ -292,22 +292,22 @@ php_stream_smb_mkdir(
 		return 0;
 	}
 	/* Context */
-	state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	/* Mkdir */
 	if ((smbc_mkdir = smbc_getFunctionMkdir(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Mkdir not supported");
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_mkdir(state->ctx, url, (mode_t)mode) == 0) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 1;
 	}
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Mkdir fails: %s", strerror(errno));
-	php_libsmbclient_state_free(state TSRMLS_CC);
+	php_smbclient_state_free(state TSRMLS_CC);
 	return 0;
 }
 
@@ -323,26 +323,26 @@ php_stream_smb_rmdir(
 	php_stream_context *context
 	TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state *state;
 	smbc_rmdir_fn smbc_rmdir;
 
 	/* Context */
-	state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	/* Rmdir */
 	if ((smbc_rmdir = smbc_getFunctionRmdir(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rmdir not supported");
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_rmdir(state->ctx, url) == 0) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 1;
 	}
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rmdir fails: %s", strerror(errno));
-	php_libsmbclient_state_free(state TSRMLS_CC);
+	php_smbclient_state_free(state TSRMLS_CC);
 	return 0;
 }
 
@@ -360,25 +360,25 @@ php_stream_smb_rename(
 	php_stream_context *context
 	TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state *state;
 	smbc_rename_fn smbc_rename;
 
 	/* Context */
-	state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	if ((smbc_rename = smbc_getFunctionRename(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rename not supported");
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_rename(state->ctx, url_from, state->ctx, url_to) == 0) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 1;
 	}
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rename fails: %s", strerror(errno));
-	php_libsmbclient_state_free(state TSRMLS_CC);
+	php_smbclient_state_free(state TSRMLS_CC);
 	return 0;
 }
 
@@ -396,7 +396,7 @@ static int php_smbdir_ops_close(php_stream *stream, int close_handle TSRMLS_DC)
 			self->handle = NULL;
 		}
 	}
-	php_libsmbclient_state_free(self->state TSRMLS_CC);
+	php_smbclient_state_free(self->state TSRMLS_CC);
 	efree(self);
 	stream->abstract = NULL;
 	return EOF;
@@ -459,23 +459,23 @@ php_stream_smbdir_opener(
 	php_stream_context *context
 	STREAMS_DC TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state *state;
 	smbc_opendir_fn         smbc_opendir;
 	SMBCFILE               *handle;
 	php_smb_stream_data    *self;
 
 	/* Context */
-	state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 	if (!state) {
 		return NULL;
 	}
 	/* Directory */
 	if ((smbc_opendir = smbc_getFunctionOpendir(state->ctx)) == NULL) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return NULL;
 	}
 	if ((handle = smbc_opendir(state->ctx, path)) == NULL) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return NULL;
 	}
 	self = ecalloc(sizeof(*self), 1);
@@ -498,26 +498,26 @@ php_stream_smb_stat(
 	php_stream_context *context
 	TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state *state;
 	smbc_stat_fn smbc_stat;
 
 	/* Context */
-	state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	/* Stat */
 	if ((smbc_stat = smbc_getFunctionStat(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Stat not supported");
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return -1;
 	}
 	if (smbc_stat(state->ctx, url, &ssb->sb) >= 0) {
-		php_libsmbclient_state_free(state TSRMLS_CC);
+		php_smbclient_state_free(state TSRMLS_CC);
 		return 0;
 	}
 	/* dont display error as PHP use this method internally to check if file exists */
-	php_libsmbclient_state_free(state TSRMLS_CC);
+	php_smbclient_state_free(state TSRMLS_CC);
 	return -1;
 }
 
@@ -535,7 +535,7 @@ php_stream_smb_metadata(
 	php_stream_context *context
 	TSRMLS_DC)
 {
-	php_libsmbclient_state *state;
+	php_smbclient_state    *state;
 	smbc_chmod_fn           smbc_chmod;
 	smbc_open_fn            smbc_open;
 	smbc_utimes_fn          smbc_utimes;
@@ -551,7 +551,7 @@ php_stream_smb_metadata(
 			newtime = (struct utimbuf *)value;
 
 			/* Context */
-			state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+			state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 			if (!state) {
 				return 0;
 			}
@@ -580,7 +580,7 @@ php_stream_smb_metadata(
 		case PHP_STREAM_META_ACCESS:
 			mode = (mode_t)*(long *)value;
 			/* Context */
-			state = php_libsmbclient_state_new(context, 1 TSRMLS_CC);
+			state = php_smbclient_state_new(context, 1 TSRMLS_CC);
 			if (!state) {
 				return 0;
 			}
@@ -596,7 +596,7 @@ php_stream_smb_metadata(
 			php_error_docref1(NULL TSRMLS_CC, url, E_WARNING, "Unknown option %d for stream_metadata", option);
 			return 0;
 	}
-	php_libsmbclient_state_free(state TSRMLS_CC);
+	php_smbclient_state_free(state TSRMLS_CC);
 	if (ret == -1) {
 		php_error_docref1(NULL TSRMLS_CC, url, E_WARNING, "Operation failed: %s", strerror(errno));
 		return 0;

--- a/smbclient.c
+++ b/smbclient.c
@@ -46,17 +46,17 @@
 
 #include "php.h"
 #include "ext/standard/info.h"
-#include "php_libsmbclient.h"
+#include "php_smbclient.h"
 
 /* If Zend Thread Safety (ZTS) is defined, each thread gets its own copy of
  * the php_libsmbclient_globals structure. Else we use a single global copy: */
 #ifdef ZTS
-static int libsmbclient_globals_id;
+static int smbclient_globals_id;
 #else
-static php_libsmbclient_globals libsmbclient_globals;
+static php_smbclient_globals smbclient_globals;
 #endif
 
-static void php_libsmbclient_init_globals(php_libsmbclient_globals *libsmbclient_globals_p TSRMLS_DC)
+static void php_smbclient_init_globals(php_smbclient_globals *smbclient_globals_p TSRMLS_DC)
 {
 	/* This function initializes the thread-local storage.
 	 * We currently don't use this. */
@@ -263,7 +263,7 @@ ZEND_END_ARG_INFO()
 
 /* }}} */
 
-static zend_function_entry libsmbclient_functions[] =
+static zend_function_entry smbclient_functions[] =
 {
 	PHP_FE(smbclient_version, arginfo_smbclient_void)
 	PHP_FE(smbclient_library_version, arginfo_smbclient_void)
@@ -304,21 +304,35 @@ static zend_function_entry libsmbclient_functions[] =
 #endif
 };
 
-zend_module_entry libsmbclient_module_entry =
+zend_module_entry smbclient_module_entry =
 	{ STANDARD_MODULE_HEADER
-	, "libsmbclient"		/* name                  */
-	, libsmbclient_functions	/* functions             */
+	, "smbclient"		/* name                  */
+	, smbclient_functions	/* functions             */
 	, PHP_MINIT(smbclient)		/* module_startup_func   */
 	, PHP_MSHUTDOWN(smbclient)	/* module_shutdown_func  */
 	, PHP_RINIT(smbclient)		/* request_startup_func  */
 	, NULL				/* request_shutdown_func */
 	, PHP_MINFO(smbclient)		/* info_func             */
-	, LIBSMBCLIENT_VERSION		/* version               */
+	, PHP_SMBCLIENT_VERSION		/* version               */
 	, STANDARD_MODULE_PROPERTIES
 	} ;
 
-#ifdef COMPILE_DL_LIBSMBCLIENT
-ZEND_GET_MODULE(libsmbclient)
+zend_module_entry old_module_entry = {
+	STANDARD_MODULE_HEADER,
+	"libsmbclient",
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	PHP_SMBCLIENT_VERSION,
+	STANDARD_MODULE_PROPERTIES,
+};
+
+
+#ifdef COMPILE_DL_SMBCLIENT
+ZEND_GET_MODULE(smbclient)
 #endif
 
 static void
@@ -418,9 +432,9 @@ PHP_MINIT_FUNCTION(smbclient)
 	/* If ZTS is defined, allocate and init a copy of the global
 	 * datastructure for each thread: */
 	#ifdef ZTS
-	ts_allocate_id(&libsmbclient_globals_id, sizeof(php_libsmbclient_globals), (ts_allocate_ctor) php_libsmbclient_init_globals, NULL);
+	ts_allocate_id(&smbclient_globals_id, sizeof(php_smbclient_globals), (ts_allocate_ctor) php_smbclient_init_globals, NULL);
 	#else
-	php_libsmbclient_init_globals(&libsmbclient_globals);
+	php_smbclient_init_globals(&smbclient_globals);
 	#endif
 
 	/* Constants for smbclient_setxattr: */
@@ -470,6 +484,9 @@ PHP_MINIT_FUNCTION(smbclient)
 
 	php_register_url_stream_wrapper("smb", &php_stream_smb_wrapper TSRMLS_CC);
 
+	/* register with old name for code using extension_loaded(libsmbclient) */
+	zend_register_internal_module(&old_module_entry TSRMLS_CC);
+
 	return SUCCESS;
 }
 
@@ -486,8 +503,8 @@ PHP_MSHUTDOWN_FUNCTION(smbclient)
 PHP_MINFO_FUNCTION(smbclient)
 {
 	php_info_print_table_start();
-	php_info_print_table_row(2, "libsmbclient Support", "enabled");
-	php_info_print_table_row(2, "libsmbclient extension Version", LIBSMBCLIENT_VERSION);
+	php_info_print_table_row(2, "smbclient Support", "enabled");
+	php_info_print_table_row(2, "smbclient extension Version", PHP_SMBCLIENT_VERSION);
 	php_info_print_table_row(2, "libsmbclient library Version", smbc_version());
 	php_info_print_table_end();
 }
@@ -645,9 +662,9 @@ PHP_FUNCTION(smbclient_version)
 		RETURN_FALSE;
 	}
 #if PHP_MAJOR_VERSION >= 7
-	RETURN_STRING(LIBSMBCLIENT_VERSION);
+	RETURN_STRING(PHP_SMBCLIENT_VERSION);
 #else
-	RETURN_STRING(LIBSMBCLIENT_VERSION, 1);
+	RETURN_STRING(PHP_SMBCLIENT_VERSION, 1);
 #endif
 }
 

--- a/tests/StreamsTest.php
+++ b/tests/StreamsTest.php
@@ -194,4 +194,12 @@ class StreamsTest extends PHPUnit_Framework_TestCase
 		$fi = new finfo(FILEINFO_MIME_TYPE);
 		$this->assertEquals('text/plain', $fi->file($this->readuri));
 	}
+
+	public function
+	testListShares ()
+	{
+		$smb = scandir('smb://'.SMB_USER.':'.SMB_PASS.'@'.SMB_HOST.'/');
+
+		$this->assertContains(SMB_SHARE, $smb, print_r($smb, true));
+	}
 }


### PR DESCRIPTION
Some notices about this PR

* switch to  "--enable-smbclient" but keep "--with-libsmbclient" for library location
* add library check for smbc_getOptionUserData symbol (seems mandatory and not available in old version, e.g. samba 3.0 in RHEL-5)
* rename constant to PHP_SMBCLIENT_VERSION (normalized for pecl)
* use .gitignore to have a clean "git status" without any untracked file
* still register "libsmbclient" ext to not break code (this probably could be dropped later)