### PR TITLE
optimize stream wrapper reusing connections

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,16 +25,16 @@
   <date>2016-02-29</date>
   <time>12:00:00</time>
   <version>
-    <release>0.8.0</release>
+    <release>0.9.0dev</release>
     <api>0.8.0</api>
   </version>
   <stability>
-    <release>stable</release>
+    <release>beta</release>
     <api>stable</api>
   </stability>
   <license uri="http://opensource.org/licenses/BSD-2-Clause">BSD 2-clause</license>
   <notes>
-- Promoting to stable after almost 3 months with no commits needed.
+- stream optimization: reuse previous connections (Remi)
   </notes>
   <contents>
     <dir name="/">
@@ -80,4 +80,39 @@
   </dependencies>
   <providesextension>smbclient</providesextension>
   <extsrcrelease/>
+  <changelog>
+    <release>
+      <date>2016-02-29</date>
+      <version>
+        <release>0.8.0dev</release>
+        <api>0.8.0</api>
+      </version>
+      <stability>
+        <release>stable</release>
+        <api>stable</api>
+      </stability>
+      <license uri="http://opensource.org/licenses/BSD-2-Clause">BSD 2-clause</license>
+      <notes>
+- Promoting to stable after almost 3 months with no commits needed.
+      </notes>
+    </release>
+    <release>
+     <date>2015-12-08</date>
+     <version>
+      <release>0.8.0RC1</release>
+      <api>0.8.0</api>
+     </version>
+     <stability>
+      <release>beta</release>
+      <api>stable</api>
+     </stability>
+     <license uri="http://opensource.org/licenses/BSD-2-Clause">BSD 2-clause</license>
+     <notes>
+- initial PECL release
+- add &apos;smb&apos; streams support
+- rename extension to smbclient
+- PHP 7 compatibility
+     </notes>
+    </release>
+  </changelog>
 </package>

--- a/php_smbclient.h
+++ b/php_smbclient.h
@@ -43,7 +43,7 @@
 
 #include <libsmbclient.h>
 
-#define PHP_SMBCLIENT_VERSION "0.8.0"
+#define PHP_SMBCLIENT_VERSION "0.9.0-dev"
 
 extern zend_module_entry smbclient_module_entry;
 #define phpext_smbclient_ptr &smbclient_module_entry

--- a/php_smbclient.h
+++ b/php_smbclient.h
@@ -66,6 +66,7 @@ php_smbclient_state;
 
 PHP_MINIT_FUNCTION(smbclient);
 PHP_MSHUTDOWN_FUNCTION(smbclient);
+PHP_RSHUTDOWN_FUNCTION(smbclient);
 PHP_RINIT_FUNCTION(smbclient);
 PHP_MINFO_FUNCTION(smbclient);
 PHP_FUNCTION(smbclient_version);
@@ -116,5 +117,6 @@ php_smbclient_state * php_smbclient_state_new  (php_stream_context *context, int
 void                  php_smbclient_state_free (php_smbclient_state *state TSRMLS_DC);
 int                   php_smbclient_state_init (php_smbclient_state *state TSRMLS_DC);
 int                   flagstring_to_smbflags (const char *flags, int flags_len, int *retval TSRMLS_DC);
+void                  php_smb_pool_cleanup(void);
 
 #endif /* PHP_SMBCLIENT_H */

--- a/php_smbclient.h
+++ b/php_smbclient.h
@@ -48,9 +48,6 @@
 extern zend_module_entry smbclient_module_entry;
 #define phpext_smbclient_ptr &smbclient_module_entry
 
-typedef struct {
-} php_smbclient_globals;
-
 typedef struct _php_smbclient_state
 {
 	SMBCCTX *ctx;
@@ -64,11 +61,25 @@ typedef struct _php_smbclient_state
 }
 php_smbclient_state;
 
+struct _php_smb_pool {
+	unsigned char          hash[20];
+	php_smbclient_state    *state;
+	struct _php_smb_pool   *next;
+	int                    nb;
+};
+
+ZEND_BEGIN_MODULE_GLOBALS(smbclient)
+	struct _php_smb_pool *pool_first;
+ZEND_END_MODULE_GLOBALS(smbclient)
+
+extern ZEND_DECLARE_MODULE_GLOBALS(smbclient)
+
 PHP_MINIT_FUNCTION(smbclient);
 PHP_MSHUTDOWN_FUNCTION(smbclient);
 PHP_RSHUTDOWN_FUNCTION(smbclient);
 PHP_RINIT_FUNCTION(smbclient);
 PHP_MINFO_FUNCTION(smbclient);
+PHP_GINIT_FUNCTION(smbclient);
 PHP_FUNCTION(smbclient_version);
 PHP_FUNCTION(smbclient_library_version);
 PHP_FUNCTION(smbclient_state_new);
@@ -106,10 +117,15 @@ PHP_FUNCTION(smbclient_fstatvfs);
  * php_smbclient_globals structure, the elements of which it can access
  * through the SMBCLIENT() macro. Without ZTS, there is just one master
  * structure in which we access the members directly: */
+
+#if PHP_MAJOR_VERSION >= 7
+#define SMBCLIENT_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(smbclient, v)
+#else
 #ifdef ZTS
-#define SMBCLIENT_G(v) TSRMG(smbclient_globals_id, php_smbclient_globals *, v)
+#define SMBCLIENT_G(v) TSRMG(smbclient_globals_id, zend_smbclient_globals *, v)
 #else
 #define SMBCLIENT_G(v) (smbclient_globals.v)
+#endif
 #endif
 
 php_stream_wrapper php_stream_smb_wrapper;

--- a/smb_streams.c
+++ b/smb_streams.c
@@ -46,6 +46,7 @@
 #include "ext/standard/url.h"
 #include "ext/standard/info.h"
 #include "ext/standard/php_filestat.h"
+#include "ext/standard/sha1.h"
 #include "php_smbclient.h"
 
 #include <libsmbclient.h>
@@ -62,6 +63,112 @@ typedef struct _php_smb_stream_data {
 	smbc_write_fn           smbc_write;
 	smbc_lseek_fn           smbc_lseek;
 } php_smb_stream_data;
+
+struct _php_smb_pool {
+	unsigned char          hash[20];
+	php_smbclient_state    *state;
+	struct _php_smb_pool   *next;
+	int                    nb;
+};
+
+struct _php_smb_pool *first = NULL;
+
+
+static php_smbclient_state *php_smb_pool_get(php_stream_context *context, const char *url TSRMLS_DC)
+{
+	PHP_SHA1_CTX          sha1;
+	unsigned char         hash[20];
+	struct _php_smb_pool *pool;
+
+	/* Create a hash for connection parameter */
+	PHP_SHA1Init(&sha1);
+	if (!memcmp(url, "smb://", 6)) {
+		char *p;
+		p = strchr(url+6, '/'); // we only want smb://workgroup;user:pass@server/
+		PHP_SHA1Update(&sha1, (const unsigned char *)url+6, p ? p - url - 6 : strlen(url+6));
+	}
+	if (context) {
+#if PHP_MAJOR_VERSION >= 7
+		zval *tmpzval;
+
+		if (NULL != (tmpzval = php_stream_context_get_option(context, "smb", "workgroup"))) {
+			if (Z_TYPE_P(tmpzval) == IS_STRING) {
+				PHP_SHA1Update(&sha1, (const unsigned char *)Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval)+1);
+			}
+		}
+		if (NULL != (tmpzval = php_stream_context_get_option(context, "smb", "username"))) {
+			if (Z_TYPE_P(tmpzval) == IS_STRING) {
+				PHP_SHA1Update(&sha1, (const unsigned char *)Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval)+1);
+			}
+		}
+		if (NULL != (tmpzval = php_stream_context_get_option(context, "smb", "password"))) {
+			if (Z_TYPE_P(tmpzval) == IS_STRING) {
+				PHP_SHA1Update(&sha1, (const unsigned char *)Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval)+1);
+			}
+		}
+#else
+		zval **tmpzval;
+
+		if (php_stream_context_get_option(context, "smb", "workgroup", &tmpzval) == SUCCESS) {
+			if (Z_TYPE_PP(tmpzval) == IS_STRING) {
+				PHP_SHA1Update(&sha1, (const unsigned char *)Z_STRVAL_PP(tmpzval), Z_STRLEN_PP(tmpzval)+1);
+			}
+		}
+		if (php_stream_context_get_option(context, "smb", "username", &tmpzval) == SUCCESS) {
+			if (Z_TYPE_PP(tmpzval) == IS_STRING) {
+				PHP_SHA1Update(&sha1, (const unsigned char *)Z_STRVAL_PP(tmpzval), Z_STRLEN_PP(tmpzval)+1);
+			}
+		}
+		if (php_stream_context_get_option(context, "smb", "password", &tmpzval) == SUCCESS) {
+			if (Z_TYPE_PP(tmpzval) == IS_STRING) {
+				PHP_SHA1Update(&sha1, (const unsigned char *)Z_STRVAL_PP(tmpzval), Z_STRLEN_PP(tmpzval)+1);
+			}
+		}
+#endif
+	}
+	PHP_SHA1Final(hash, &sha1);
+
+	/* Reuse state from pool if exists */
+	for (pool=first; pool ; pool=pool->next) {
+		if (!memcmp(hash, pool->hash, 20)) {
+			pool->nb++;
+			return pool->state;
+		}
+	}
+
+	/* Crate a new state and save it in the pool */
+	pool = emalloc(sizeof(*pool));
+	memcpy(pool->hash, hash, 20);
+	pool->nb    = 1;
+	pool->next  = first;
+	pool->state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	first = pool;
+
+	return pool->state;
+}
+
+static void php_smb_pool_drop(php_smbclient_state *state TSRMLS_DC)
+{
+	struct _php_smb_pool *pool;
+
+	for (pool=first; pool; pool=pool->next) {
+		if (pool->state==state) {
+			pool->nb--;
+		}
+	}
+}
+
+void php_smb_pool_cleanup(void) {
+	struct _php_smb_pool *pool;
+
+	pool = first;
+	while (pool) {
+		php_smbclient_state_free(pool->state TSRMLS_CC);
+		pool=pool->next;
+		efree(pool);
+	}
+	first = NULL;
+}
 
 static int php_smb_ops_close(php_stream *stream, int close_handle TSRMLS_DC)
 {
@@ -81,7 +188,7 @@ static int php_smb_ops_close(php_stream *stream, int close_handle TSRMLS_DC)
 		}
 	}
 
-	php_smbclient_state_free(self->state TSRMLS_CC);
+	php_smb_pool_drop(self->state TSRMLS_CC);
 	efree(self);
 	stream->abstract = NULL;
 	return EOF;
@@ -203,7 +310,7 @@ php_stream_smb_opener(
 	php_smb_stream_data    *self;
 
 	/* Context */
-	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smb_pool_get(context, path TSRMLS_CC);
 	if (!state) {
 		return NULL;
 	}
@@ -214,15 +321,15 @@ php_stream_smb_opener(
 		mode = "r";
 	}
 	if (flagstring_to_smbflags(mode, strlen(mode), &smbflags TSRMLS_CC) == 0) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return NULL;
 	}
 	if ((smbc_open = smbc_getFunctionOpen(state->ctx)) == NULL) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return NULL;
 	}
 	if ((handle = smbc_open(state->ctx, path, smbflags, smbmode)) == NULL) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return NULL;
 	}
 	self = ecalloc(sizeof(*self), 1);
@@ -248,7 +355,7 @@ php_stream_smb_unlink(
 	smbc_unlink_fn smbc_unlink;
 
 	/* Context */
-	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smb_pool_get(context, url TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
@@ -257,17 +364,17 @@ php_stream_smb_unlink(
 		if (options & REPORT_ERRORS) {
 			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unlink not supported");
 		}
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_unlink(state->ctx, url) == 0) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 1;
 	}
 	if (options & REPORT_ERRORS) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unlink fails: %s", strerror(errno));
 	}
-	php_smbclient_state_free(state TSRMLS_CC);
+	php_smb_pool_drop(state TSRMLS_CC);
 	return 0;
 }
 
@@ -292,22 +399,22 @@ php_stream_smb_mkdir(
 		return 0;
 	}
 	/* Context */
-	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smb_pool_get(context, url TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	/* Mkdir */
 	if ((smbc_mkdir = smbc_getFunctionMkdir(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Mkdir not supported");
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_mkdir(state->ctx, url, (mode_t)mode) == 0) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 1;
 	}
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Mkdir fails: %s", strerror(errno));
-	php_smbclient_state_free(state TSRMLS_CC);
+	php_smb_pool_drop(state TSRMLS_CC);
 	return 0;
 }
 
@@ -327,22 +434,22 @@ php_stream_smb_rmdir(
 	smbc_rmdir_fn smbc_rmdir;
 
 	/* Context */
-	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smb_pool_get(context, url TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	/* Rmdir */
 	if ((smbc_rmdir = smbc_getFunctionRmdir(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rmdir not supported");
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_rmdir(state->ctx, url) == 0) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 1;
 	}
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rmdir fails: %s", strerror(errno));
-	php_smbclient_state_free(state TSRMLS_CC);
+	php_smb_pool_drop(state TSRMLS_CC);
 	return 0;
 }
 
@@ -364,21 +471,21 @@ php_stream_smb_rename(
 	smbc_rename_fn smbc_rename;
 
 	/* Context */
-	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smb_pool_get(context, url_from TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	if ((smbc_rename = smbc_getFunctionRename(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rename not supported");
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 0;
 	}
 	if (smbc_rename(state->ctx, url_from, state->ctx, url_to) == 0) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 1;
 	}
 	php_error_docref(NULL TSRMLS_CC, E_WARNING, "Rename fails: %s", strerror(errno));
-	php_smbclient_state_free(state TSRMLS_CC);
+	php_smb_pool_drop(state TSRMLS_CC);
 	return 0;
 }
 
@@ -396,7 +503,7 @@ static int php_smbdir_ops_close(php_stream *stream, int close_handle TSRMLS_DC)
 			self->handle = NULL;
 		}
 	}
-	php_smbclient_state_free(self->state TSRMLS_CC);
+	php_smb_pool_drop(self->state TSRMLS_CC);
 	efree(self);
 	stream->abstract = NULL;
 	return EOF;
@@ -465,17 +572,17 @@ php_stream_smbdir_opener(
 	php_smb_stream_data    *self;
 
 	/* Context */
-	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smb_pool_get(context, path TSRMLS_CC);
 	if (!state) {
 		return NULL;
 	}
 	/* Directory */
 	if ((smbc_opendir = smbc_getFunctionOpendir(state->ctx)) == NULL) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return NULL;
 	}
 	if ((handle = smbc_opendir(state->ctx, path)) == NULL) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return NULL;
 	}
 	self = ecalloc(sizeof(*self), 1);
@@ -502,22 +609,22 @@ php_stream_smb_stat(
 	smbc_stat_fn smbc_stat;
 
 	/* Context */
-	state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+	state = php_smb_pool_get(context, url TSRMLS_CC);
 	if (!state) {
 		return 0;
 	}
 	/* Stat */
 	if ((smbc_stat = smbc_getFunctionStat(state->ctx)) == NULL) {
 		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Stat not supported");
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return -1;
 	}
 	if (smbc_stat(state->ctx, url, &ssb->sb) >= 0) {
-		php_smbclient_state_free(state TSRMLS_CC);
+		php_smb_pool_drop(state TSRMLS_CC);
 		return 0;
 	}
 	/* dont display error as PHP use this method internally to check if file exists */
-	php_smbclient_state_free(state TSRMLS_CC);
+	php_smb_pool_drop(state TSRMLS_CC);
 	return -1;
 }
 
@@ -551,7 +658,7 @@ php_stream_smb_metadata(
 			newtime = (struct utimbuf *)value;
 
 			/* Context */
-			state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+			state = php_smb_pool_get(context, url TSRMLS_CC);
 			if (!state) {
 				return 0;
 			}
@@ -580,7 +687,7 @@ php_stream_smb_metadata(
 		case PHP_STREAM_META_ACCESS:
 			mode = (mode_t)*(long *)value;
 			/* Context */
-			state = php_smbclient_state_new(context, 1 TSRMLS_CC);
+			state = php_smb_pool_get(context, url TSRMLS_CC);
 			if (!state) {
 				return 0;
 			}
@@ -596,7 +703,7 @@ php_stream_smb_metadata(
 			php_error_docref1(NULL TSRMLS_CC, url, E_WARNING, "Unknown option %d for stream_metadata", option);
 			return 0;
 	}
-	php_smbclient_state_free(state TSRMLS_CC);
+	php_smb_pool_drop(state TSRMLS_CC);
 	if (ret == -1) {
 		php_error_docref1(NULL TSRMLS_CC, url, E_WARNING, "Operation failed: %s", strerror(errno));
 		return 0;

--- a/smbclient.c
+++ b/smbclient.c
@@ -48,19 +48,7 @@
 #include "ext/standard/info.h"
 #include "php_smbclient.h"
 
-/* If Zend Thread Safety (ZTS) is defined, each thread gets its own copy of
- * the php_smbclient_globals structure. Else we use a single global copy: */
-#ifdef ZTS
-static int smbclient_globals_id;
-#else
-static php_smbclient_globals smbclient_globals;
-#endif
-
-static void php_smbclient_init_globals(php_smbclient_globals *smbclient_globals_p TSRMLS_DC)
-{
-	/* This function initializes the thread-local storage.
-	 * We currently don't use this. */
-}
+ZEND_DECLARE_MODULE_GLOBALS(smbclient)
 
 #define PHP_SMBCLIENT_STATE_NAME "smbclient state"
 #define PHP_SMBCLIENT_FILE_NAME "smbclient file"
@@ -314,7 +302,11 @@ zend_module_entry smbclient_module_entry =
 	, PHP_RSHUTDOWN(smbclient)	/* request_shutdown_func */
 	, PHP_MINFO(smbclient)		/* info_func             */
 	, PHP_SMBCLIENT_VERSION		/* version               */
-	, STANDARD_MODULE_PROPERTIES
+	, PHP_MODULE_GLOBALS(smbclient)
+	, PHP_GINIT(smbclient)		/* globals ctor */
+	, NULL						/* globals dtor */
+	, NULL						/* post_deactivate_func */
+	, STANDARD_MODULE_PROPERTIES_EX
 	} ;
 
 zend_module_entry old_module_entry = {
@@ -427,16 +419,13 @@ smbclient_file_dtor (
 	 * associated context is destroyed. */
 }
 
+PHP_GINIT_FUNCTION(smbclient)
+{
+	smbclient_globals->pool_first = NULL;
+}
+
 PHP_MINIT_FUNCTION(smbclient)
 {
-	/* If ZTS is defined, allocate and init a copy of the global
-	 * datastructure for each thread: */
-	#ifdef ZTS
-	ts_allocate_id(&smbclient_globals_id, sizeof(php_smbclient_globals), (ts_allocate_ctor) php_smbclient_init_globals, NULL);
-	#else
-	php_smbclient_init_globals(&smbclient_globals);
-	#endif
-
 	/* Constants for smbclient_setxattr: */
 	REGISTER_LONG_CONSTANT("SMBCLIENT_XATTR_CREATE", SMBC_XATTR_FLAG_CREATE, CONST_PERSISTENT | CONST_CS);
 	REGISTER_LONG_CONSTANT("SMBCLIENT_XATTR_REPLACE", SMBC_XATTR_FLAG_REPLACE, CONST_PERSISTENT | CONST_CS);

--- a/smbclient.c
+++ b/smbclient.c
@@ -311,7 +311,7 @@ zend_module_entry smbclient_module_entry =
 	, PHP_MINIT(smbclient)		/* module_startup_func   */
 	, PHP_MSHUTDOWN(smbclient)	/* module_shutdown_func  */
 	, PHP_RINIT(smbclient)		/* request_startup_func  */
-	, NULL				/* request_shutdown_func */
+	, PHP_RSHUTDOWN(smbclient)	/* request_shutdown_func */
 	, PHP_MINFO(smbclient)		/* info_func             */
 	, PHP_SMBCLIENT_VERSION		/* version               */
 	, STANDARD_MODULE_PROPERTIES
@@ -497,6 +497,12 @@ PHP_RINIT_FUNCTION(smbclient)
 
 PHP_MSHUTDOWN_FUNCTION(smbclient)
 {
+	return SUCCESS;
+}
+
+PHP_RSHUTDOWN_FUNCTION(smbclient)
+{
+	php_smb_pool_cleanup();
 	return SUCCESS;
 }
 


### PR DESCRIPTION
Open for discussion (but code is ready)

This should greatly improve stream wrapper usage.

Using this script:
```
<?php
define('BASEURL', 'smb://foo:bar@server/testshare/');

printf("Start\n");
$time = microtime(true);
function dumpdir($dir, $ind=4) {
	$names = @scandir($dir);
	if (!is_array($names)) {
		printf("%s  access denied\n", str_repeat(' ', $ind));
		return;
	}
	foreach($names as $name) {
		$stat = stat("$dir/$name");
		printf("%s %s (%08o)\n", str_repeat(' ', $ind), $name, isset($stat['mode']) ? $stat['mode'] : 0);
		if ($name[0]!='.' && is_dir("$dir/$name")) {
			dumpdir("$dir/$name", $ind+4);
		}
	}
}
dumpdir(BASEURL);

$time = microtime(true) - $time;
printf("Done in %.3f\"\n", $time);
```

* Without this change: Done in **0.070"**
* With this change: Done in **0.009"**

For now, connection are only reused during a single request.

Another idea will be to introduce "persistent" connections (across various requests), but this will imply more adaptations.