### PR TITLE
Fix CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ script:
   - phpize
   - ./configure
   - make
-  - sudo make install INSTALL_ROOT=$(/usr/bin/php -i | grep -E '^extension_dir =>' | awk -F' => ' '{print $3}')
+  - sudo make install
   - echo 'extension="smbclient.so"' | sudo tee -a /etc/php5/cli/php.ini
-  - /usr/bin/php phpunit.phar --verbose
+  - php phpunit.phar --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,4 @@ script:
   - ./configure
   - make
   - sudo make install
-  - echo 'extension="smbclient.so"' | sudo tee -a /etc/php5/cli/php.ini
-  - php phpunit.phar --verbose
+  - php --define extension="smbclient.so" phpunit.phar --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ script:
   - phpize
   - ./configure
   - make
-  - sudo make install
+  - sudo make install INSTALL_ROOT=$(/usr/bin/php -i | grep -E '^extension_dir =>' | awk -F' => ' '{print $3}')
   - echo 'extension="smbclient.so"' | sudo tee -a /etc/php5/cli/php.ini
   - /usr/bin/php phpunit.phar --verbose


### PR DESCRIPTION
According to the error messages here: https://travis-ci.org/eduardok/libsmbclient-php/jobs/397303214 the php-extension `smbclient` is installed somewhere in `~travis/.phpenv`, where the system php cannot find it later on for the unit tests.

I have no knowledge on php-extension writing or testing a.s.o., so this is a fast hack rather than a solution.

`~travis/.phpenv` is mentioned in the system infos of the job, and later on `./configure` seems to pick that up to determine the various php directories. Is there's a separate installation of php in the home, using `/usr/bin/php` rather than just `php` might have caused the problem.