### PR TITLE
fix string free

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,12 +28,14 @@ config.cache
 config.guess
 config.h
 config.h.in
+config.h.in~
 config.log
 config.nice
 config.status
 config.sub
 configure
 configure.in
+configure.ac
 conftest
 conftest.c
 Makefile

--- a/smbclient.c
+++ b/smbclient.c
@@ -1345,15 +1345,17 @@ PHP_FUNCTION(smbclient_read)
 
 	if ((ZSTR_LEN(buf) = smbc_read(state->ctx, file, ZSTR_VAL(buf), count)) >= 0) {
 		RETURN_STR(buf);
+	}
+	zend_string_release(buf);
 #else
 	void *buf = emalloc(count);
 	ssize_t nbytes;
 
 	if ((nbytes = smbc_read(state->ctx, file, buf, count)) >= 0) {
 		RETURN_STRINGL(buf, nbytes, 0);
-#endif
 	}
 	efree(buf);
+#endif
 	switch (state->err = errno) {
 		case EISDIR: php_error(E_WARNING, "Read error: Is a directory"); break;
 		case EBADF: php_error(E_WARNING, "Read error: Not a valid file resource or not open for reading"); break;
@@ -1738,7 +1740,7 @@ PHP_FUNCTION(smbclient_removexattr)
 PHP_FUNCTION(smbclient_option_get)
 {
 	zend_long option;
-	char *ret;
+	const char *ret;
 	zval *zstate;
 	php_smbclient_state *state;
 

--- a/tests/ReadTest.php
+++ b/tests/ReadTest.php
@@ -1,0 +1,44 @@
+<?php
+
+class ReadTest extends PHPUnit_Framework_TestCase
+{
+	private $testdata =
+		"Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+		sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n";
+
+	// The URI of the test file seen through Samba:
+	private $testuri;
+
+	// The "real" file on the filesystem:
+	private $realfile;
+
+	public function
+	setup()
+	{
+		$this->testuri = 'smb://'.SMB_HOST.'/'.SMB_SHARE.'/readtest.txt';
+		$this->realfile = SMB_LOCAL.'/readtest.txt';
+
+		file_put_contents($this->realfile, $this->testdata);
+	}
+
+	public function
+	tearDown()
+	{
+		@unlink($this->realfile);
+	}
+
+	public function
+	testReadSuccess()
+	{
+		$state = smbclient_state_new();
+		smbclient_state_init($state, null, SMB_USER, SMB_PASS);
+		$file = smbclient_open($state, $this->testuri, 'r');
+		$this->assertTrue(is_resource($file));
+
+		for ($data = ''; $tmp = smbclient_read($state, $file, 42) ; $data .= $tmp) {
+			$this->assertTrue(\strlen($tmp) > 0 && \strlen($tmp <= 42));
+		}
+		$this->assertEmpty($tmp);
+		$this->assertEquals($this->testdata, $data);
+	}
+}


### PR DESCRIPTION
Initially reported as PR #64 

Also fix a small build warning [-Wdiscarded-qualifiers]

```
/dev/shm/BUILD/php-smbclient-1.0.0/ZTS/smbclient.c: In function 'zif_smbclient_option_get':
/dev/shm/BUILD/php-smbclient-1.0.0/ZTS/smbclient.c:1794:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   if ((ret = smbc_getNetbiosName(state->ctx)) == NULL) {
            ^
/dev/shm/BUILD/php-smbclient-1.0.0/ZTS/smbclient.c:1807:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   if ((ret = smbc_getWorkgroup(state->ctx)) == NULL) {
            ^
/dev/shm/BUILD/php-smbclient-1.0.0/ZTS/smbclient.c:1819:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   if ((ret = smbc_getUser(state->ctx)) == NULL) {
            ^

```
