### PR TITLE
look for headers in include/samba-* for --with-libsmbclient

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -13,7 +13,12 @@ if test "$PHP_SMBCLIENT" != "no"; then
   if test "$PHP_LIBSMBCLIENT" != "yes"; then
 
     LIBSMBCLIENT_DIR=$PHP_LIBSMBCLIENT/$PHP_LIBDIR
-    LIBSMBCLIENT_INCDIR=$PHP_LIBSMBCLIENT/include
+    for i in $PHP_LIBSMBCLIENT/include $PHP_LIBSMBCLIENT/include/samba-* ; do
+      if test -r $i/libsmbclient.h; then
+        LIBSMBCLIENT_INCDIR="$i";
+        break;
+      fi
+    done
 
     AC_DEFINE(HAVE_LIBSMBCLIENT, 1, [ ])
     PHP_ADD_INCLUDE($LIBSMBCLIENT_INCDIR)


### PR DESCRIPTION
This allows to specify a samba install directory via --with-libsmbclient
where the header is located under include/samba-4.0/libsmbclient.h