### PR TITLE
Fix for 7.4 and 8.0

### DIFF
--- a/php_smbclient.h
+++ b/php_smbclient.h
@@ -128,6 +128,14 @@ PHP_FUNCTION(smbclient_fstatvfs);
 #endif
 #endif
 
+#if PHP_MAJOR_VERSION >= 8
+#define TSRMLS_D void
+#define TSRMLS_DC
+#define TSRMLS_C
+#define TSRMLS_CC
+#define TSRMLS_FETCH()
+#endif
+
 extern php_stream_wrapper php_stream_smb_wrapper;
 php_smbclient_state * php_smbclient_state_new  (php_stream_context *context, int init TSRMLS_DC);
 void                  php_smbclient_state_free (php_smbclient_state *state TSRMLS_DC);

--- a/smb_streams.c
+++ b/smb_streams.c
@@ -190,7 +190,11 @@ static int php_smb_ops_flush(php_stream *stream TSRMLS_DC)
 	return 0;
 }
 
+#if PHP_VERSION_ID < 70400
 static size_t php_smb_ops_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+#else
+static ssize_t php_smb_ops_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+#endif
 {
 	ssize_t n = 0;
 	STREAM_DATA_FROM_STREAM();
@@ -208,12 +212,20 @@ static size_t php_smb_ops_read(php_stream *stream, char *buf, size_t count TSRML
 	if (n == 0 || n < (ssize_t)count) {
 		stream->eof = 1;
 	}
+#if PHP_VERSION_ID < 70400
 	return (n < 1 ? 0 : (size_t)n);
+#else
+	return n;
+#endif
 }
 
+#if PHP_VERSION_ID < 70400
 static size_t php_smb_ops_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC)
+#else
+static ssize_t php_smb_ops_write(php_stream *stream, const char *buf, size_t count TSRMLS_DC)
+#endif
 {
-	size_t len = 0;
+	ssize_t len = 0;
 	STREAM_DATA_FROM_STREAM();
 
 	if (!self || !self->handle) {
@@ -225,7 +237,12 @@ static size_t php_smb_ops_write(php_stream *stream, const char *buf, size_t coun
 	if (self->smbc_write) {
 		len = self->smbc_write(self->state->ctx, self->handle, buf, count);
 	}
+
+#if PHP_VERSION_ID < 70400
+	return (len < 0 ? 0 : (size_t)len);
+#else
 	return len;
+#endif
 }
 
 static int php_smb_ops_stat(php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC) /* {{{ */
@@ -500,7 +517,11 @@ static int php_smbdir_ops_close(php_stream *stream, int close_handle TSRMLS_DC)
 	return EOF;
 }
 
+#if PHP_VERSION_ID < 70400
 static size_t php_smbdir_ops_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+#else
+static ssize_t php_smbdir_ops_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+#endif
 {
 	struct smbc_dirent *dirent;
 	php_stream_dirent *ent = (php_stream_dirent*)buf;


### PR DESCRIPTION
* 1st commit is for 7.4, stream operation now use -1 for error (0 for empty)

```
  y. The read and write operations of php_stream_ops now return ssize_t, with
     negative values indicating an error.

```

* 2nd commit is for 8.0, TSRMLS_ macros are not used in 7, removed in 8

```
  c. The following things have been removed from TSRM:
      - TSRMLS_DC
      - TSRMLS_D
      - TSRMLS_CC
      - TSRMLS_C
      - TSRMLS_FETCH
      - TSRMLS_FETCH_FROM_CTX
      - TSRMLS_SET_CTX
      - tsrm_new_interpreter_context
      - tsrm_set_interpreter_context
      - tsrm_free_interpreter_context
      - support for GNUPTH, SGI ST, and BETHREADS

```