### PR TITLE
Improve min/maxproto management

### DIFF
--- a/smbclient.c
+++ b/smbclient.c
@@ -615,6 +615,12 @@ php_smbclient_state_new (php_stream_context *context, int init TSRMLS_DC)
 				return NULL;
 			}
 		}
+		if (NULL != (tmpzval = php_stream_context_get_option(context, "smb", "minproto"))) {
+			smbc_setOptionProtocols(state->ctx, Z_STRVAL_P(tmpzval), NULL);
+		}
+		if (NULL != (tmpzval = php_stream_context_get_option(context, "smb", "maxproto"))) {
+			smbc_setOptionProtocols(state->ctx, NULL, Z_STRVAL_P(tmpzval));
+		}
 #else
 		zval **tmpzval;
 
@@ -635,6 +641,12 @@ php_smbclient_state_new (php_stream_context *context, int init TSRMLS_DC)
 				php_smbclient_state_free(state TSRMLS_CC);
 				return NULL;
 			}
+		}
+		if (php_stream_context_get_option(context, "smb", "minproto", &tmpzval) == SUCCESS) {
+			smbc_setOptionProtocols(state->ctx, Z_STRVAL_PP(tmpzval), NULL);
+		}
+		if (php_stream_context_get_option(context, "smb", "maxproto", &tmpzval) == SUCCESS) {
+			smbc_setOptionProtocols(state->ctx, NULL, Z_STRVAL_PP(tmpzval));
 		}
 #endif
 	}

--- a/smbclient.c
+++ b/smbclient.c
@@ -173,7 +173,7 @@ ZEND_BEGIN_ARG_INFO(arginfo_smbclient_option_set, 0)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_smbclient_client_protocols, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_smbclient_client_protocols, 0, 0, 1)
 	ZEND_ARG_INFO(0, state)
 	ZEND_ARG_INFO(0, minproto)
 	ZEND_ARG_INFO(0, maxproto)
@@ -1958,11 +1958,11 @@ PHP_FUNCTION(smbclient_option_set)
 PHP_FUNCTION(smbclient_client_protocols)
 {
 	zval *zstate;
-	char *minproto, *maxproto;
+	char *minproto = NULL, *maxproto = NULL;
 	strsize_t minproto_len, maxproto_len;
 	php_smbclient_state *state;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rss", &zstate, &minproto, &minproto_len, &maxproto, &maxproto_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|s!s!", &zstate, &minproto, &minproto_len, &maxproto, &maxproto_len) == FAILURE) {
 		return;
 	}
 	STATE_FROM_ZSTATE;


### PR DESCRIPTION
First make arg optional, thus allow to only set one without having to know the second (matching library API)

Ex:

```
     var_dump(smbclient_client_protocols($state, 'SMB2'));
```


Second commit allow to set in context

```
$opts = [
	'smb' => [
	        'username' => 'xx',
		'password' => 'yy',
		'minproto' => 'SMB2',
		'maxproto' => 'SMB3',
	]
];
$context = stream_context_create($opts);
$txt = file_get_contents('smb://foo/bar/file.txt', false, $context);
```
